### PR TITLE
Arreglé un bug con el anclaje en celular

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=4
 [application]
 
 config/name="Juego Educativo"
-run/main_scene="res://scenes/Menu_Init.tscn"
+run/main_scene="res://scenes/world_test.tscn"
 config/icon="res://icon.png"
 
 [autoload]

--- a/scenes/boat.tscn
+++ b/scenes/boat.tscn
@@ -10,7 +10,7 @@
 extents = Vector2( 30, 18 )
 
 [sub_resource type="CapsuleShape2D" id=3]
-radius = 30.0
+radius = 40.0
 height = 35.0
 
 [sub_resource type="CircleShape2D" id=2]
@@ -56,11 +56,14 @@ collision_layer = 16
 collision_mask = 4
 
 [node name="InteractionCollision" type="CollisionShape2D" parent="Boat/InteractionArea"]
+position = Vector2( 0, -0.280617 )
 shape = SubResource( 3 )
 
 [node name="AnchorButton" type="Area2D" parent="."]
 position = Vector2( 197.808, -25.8284 )
 z_index = 10
+collision_layer = 8
+collision_mask = 0
 __meta__ = {
 "_edit_group_": true
 }

--- a/scenes/scripts/boat.gd
+++ b/scenes/scripts/boat.gd
@@ -59,12 +59,13 @@ func _on_Lever_input_event(viewport, event, shape_idx):
 
 
 func _on_AnchorButton_input_event(viewport, event, shape_idx):
-	if Input.is_action_just_pressed("ui_click"):
-		if anchored:
-			anchored = false
-		else:
-			if not $Boat/InteractionArea.get_overlapping_bodies().empty():
-				anchored = true
+	if event is InputEventMouseButton or event is InputEventScreenTouch:
+		if event.button_index == BUTTON_LEFT and not event.pressed:
+			if anchored:
+				anchored = false
+			else:
+				if not $Boat/InteractionArea.get_overlapping_bodies().empty():
+					anchored = true
 
 
 func _physics_process(delta):


### PR DESCRIPTION
Para anclar la lancha era necesario un doble toque en el botón. Ahora funciona con un toque simple